### PR TITLE
improving set_cookie security

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1904,7 +1904,7 @@ def set_cookie():
         settings['language'] = 'en'
         settings['font_size'] = '10'
         response = make_response("RadhaKrishna")
-        response.set_cookie('settings', json.dumps(settings))
+        response.set_cookie('settings', json.dumps(settings), secure=True, httponly=True, samesite='Lax')
 
     return response
 


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python 3 web projects, called Bento. While we were scanning GitHub projects for issues, it triggered a warning for the set_cookie method on your app. Looks like you use cookie for user settings (not auth) so perhaps it is no big deal but I don't think it does any harm to secure the cookies (it is 1-line change) and it prevents a malicious actor from stealing settings cookies. 

There were bunch of other warning bento triggered on but I didn't include them in this PR to keep it clean an simple. If you are curious, you can download bento from https://bento.dev/